### PR TITLE
Add resilient request coordination and refresh handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ The plugin fetches real stock data from Yahoo Finance API, which provides free a
 Features:
 - No API key required
 - Automatic caching to reduce API calls
+- Scoped refreshes that update only the symbols in the current block
+- Partial stock list results when one symbol fails, with successful rows kept visible
+- Failed refreshes keep the last successful data visible while showing the refresh error
 - Clear error messages when Yahoo Finance is unavailable
 - Real-time data updates when notes are opened
 

--- a/main.ts
+++ b/main.ts
@@ -140,13 +140,8 @@ export default class StockTickerPlugin extends Plugin {
 		refreshDataFetcher: (component: TComponent, config: TConfig) => Promise<TData>
 	): void {
 		component.refreshDataCallback = async () => {
-			try {
-				this.stockDataService.clearCache();
-				const freshData = await refreshDataFetcher(component, config);
-				await component.render(freshData);
-			} catch {
-				// Refresh errors are already shown by the rendered block when data loading fails.
-			}
+			const freshData = await refreshDataFetcher(component, config);
+			await component.render(freshData);
 		};
 	}
 

--- a/src/components/stock-chart.ts
+++ b/src/components/stock-chart.ts
@@ -6,6 +6,7 @@ import { createInteractiveChart, interpolatePrice } from '../utils/line-chart-ut
 import { createCandlestickChart, interpolateCandlestickPrice } from '../utils/candlestick-utils';
 import { getTimeRangeDescription, calculateOptimalDateRange } from '../utils/date-utils';
 import { calculatePriceRange } from '../utils/math-utils';
+import { getErrorMessage } from '../utils/error-utils';
 
 export class StockChartComponent extends Component {
 	private container: HTMLElement;
@@ -29,6 +30,7 @@ export class StockChartComponent extends Component {
 
 	async render(stockData: StockData): Promise<void> {
 		this.data = stockData;
+		this.lastUpdate = new Date();
 		this.container.empty();
 		this.container.addClass('stock-chart-container');
 
@@ -331,14 +333,29 @@ export class StockChartComponent extends Component {
 		}
 
 		try {
+			this.clearRefreshError();
 			await this.refreshDataCallback();
-			this.lastUpdate = new Date();
+		} catch (error: unknown) {
+			this.showRefreshError(getErrorMessage(error, 'Unable to refresh stock data'));
 		} finally {
 			if (refreshBtn) {
 				refreshBtn.disabled = false;
 				refreshBtn.textContent = '↻ Refresh';
 			}
 		}
+	}
+
+	private clearRefreshError(): void {
+		this.container.querySelector('.stock-refresh-error-banner')?.remove();
+	}
+
+	private showRefreshError(message: string): void {
+		this.clearRefreshError();
+
+		const banner = this.container.ownerDocument.createElement('div');
+		banner.className = 'stock-refresh-error-banner';
+		banner.textContent = `Refresh failed: ${message}. Showing last successful data.`;
+		this.container.prepend(banner);
 	}
 
 	private async renderSymbol(container: HTMLElement, symbol: string): Promise<void> {

--- a/src/components/stock-list.ts
+++ b/src/components/stock-list.ts
@@ -1,18 +1,22 @@
 import { MarkdownRenderer, Component, App } from 'obsidian';
-import { StockListBlockConfig, StockData, ChartData } from '../types';
+import { StockListBlockConfig, StockData, ChartData, StockDataError, StockListDataResult } from '../types';
 import { formatPrice, formatPercentage } from '../utils/formatters';
 import { createTooltip, hideTooltip } from '../utils/tooltip-utils';
 import { createInteractiveSparkline } from '../utils/sparkline-utils';
+import { getErrorMessage } from '../utils/error-utils';
 
 export class StockListComponent extends Component {
 	private container: HTMLElement;
 	private config: StockListBlockConfig;
 	private data: StockData[] = [];
+	private errors: StockDataError[] = [];
 	private app: App;
 	private autoRefreshInterval?: number;
 	private lastUpdate: Date = new Date();
+	private hasLoadedData = false;
 	private tooltip: HTMLElement | null = null;
 	private sparklineChartIds: string[] = [];
+	private refreshErrors = new Map<string, string>();
 	public refreshDataCallback?: () => Promise<void>;
 	private eventListeners: { element: Element; event: string; handler: EventListener }[] = [];
 
@@ -24,9 +28,22 @@ export class StockListComponent extends Component {
 		this.tooltip = createTooltip(this.container.ownerDocument);
 	}
 
-	async render(stockDataArray: StockData[]): Promise<void> {
-		this.data = stockDataArray;
-		this.lastUpdate = new Date();
+	async render(stockListData: StockListDataResult, updateTimestamp: boolean = true): Promise<void> {
+		const previousDataBySymbol = new Map(this.data.map(stock => [stock.symbol, stock]));
+		const incomingSymbols = new Set(stockListData.stocks.map(stock => stock.symbol));
+		const preservedData = stockListData.errors
+			.map(error => previousDataBySymbol.get(error.symbol))
+			.filter((stock): stock is StockData => stock !== undefined && !incomingSymbols.has(stock.symbol));
+
+		this.data = stockListData.stocks.concat(preservedData);
+		this.errors = stockListData.errors.filter(error => !previousDataBySymbol.has(error.symbol));
+		this.refreshErrors = new Map(stockListData.errors.map(error => [error.symbol, error.message]));
+
+		if (updateTimestamp && stockListData.stocks.length > 0) {
+			this.lastUpdate = new Date();
+			this.hasLoadedData = true;
+		}
+
 		this.sparklineChartIds = [];
 		
 		for (const { element, event, handler } of this.eventListeners) {
@@ -38,7 +55,7 @@ export class StockListComponent extends Component {
 		this.container.addClass('stock-list-container');
 		this.renderHeader();
 
-		if (this.data.length === 0) {
+		if (this.data.length === 0 && this.errors.length === 0) {
 			this.container.createEl('div', {
 				text: 'No stock data available',
 				cls: 'stock-list-empty'
@@ -67,9 +84,16 @@ export class StockListComponent extends Component {
 
 		for (const stock of this.data) {
 			const row = tbody.createEl('tr', { cls: 'stock-list-row' });
+			const refreshError = this.refreshErrors.get(stock.symbol);
+			if (refreshError) {
+				row.addClass('stock-list-stale-row');
+			}
 
 			const symbolCell = row.createEl('td', { cls: 'stock-symbol-cell' });
 			await this.renderSymbol(symbolCell, stock.symbol);
+			if (refreshError) {
+				this.renderRefreshFailureBadge(symbolCell, refreshError);
+			}
 
 			const priceCell = row.createEl('td', { cls: 'stock-price-cell' });
 			priceCell.setText(formatPrice(stock.price, stock.currency));
@@ -101,6 +125,10 @@ export class StockListComponent extends Component {
 			}
 		}
 
+		for (const error of this.errors) {
+			this.renderErrorRow(tbody, error);
+		}
+
 		if (this.config.showLastUpdate !== false) {
 			const bottomContainer = tableWrapper.createEl('div', { cls: 'stock-list-bottom-container' });
 			const leftSection = bottomContainer.createEl('div', { cls: 'stock-list-bottom-left' });
@@ -113,7 +141,7 @@ export class StockListComponent extends Component {
 
 			const rightSection = bottomContainer.createEl('div', { cls: 'stock-list-bottom-right' });
 			rightSection.createEl('span', {
-				text: `Last updated: ${this.lastUpdate.toLocaleTimeString()}`,
+				text: this.hasLoadedData ? `Last updated: ${this.lastUpdate.toLocaleTimeString()}` : 'No successful update yet',
 				cls: 'stock-list-info'
 			});
 
@@ -133,6 +161,51 @@ export class StockListComponent extends Component {
 		}
 
 		this.setupAutoRefresh();
+	}
+
+	private renderRefreshFailureBadge(container: HTMLElement, message: string): void {
+		const badge = container.createEl('span', {
+			text: 'Refresh failed',
+			cls: 'stock-refresh-failed-badge'
+		});
+		badge.title = message;
+	}
+
+	private renderErrorRow(tbody: HTMLElement, error: StockDataError): void {
+		const row = tbody.createEl('tr', { cls: 'stock-list-row' });
+		row.addClass('stock-list-error-row');
+
+		const symbolCell = row.createEl('td', { cls: 'stock-symbol-cell' });
+		symbolCell.setText(error.symbol);
+
+		const priceCell = row.createEl('td', { cls: 'stock-price-cell' });
+		priceCell.createEl('span', {
+			text: 'Unavailable',
+			cls: 'stock-list-error-value'
+		});
+
+		const changeCell = row.createEl('td', { cls: 'stock-change-cell' });
+		const messageEl = changeCell.createEl('span', {
+			text: error.message,
+			cls: 'stock-list-row-error-message'
+		});
+		messageEl.title = error.message;
+
+		if (this.shouldShowTodayColumn()) {
+			const todayChangeCell = row.createEl('td', { cls: 'stock-today-change-cell' });
+			todayChangeCell.createEl('span', {
+				text: 'N/A',
+				cls: 'stock-today-unavailable'
+			});
+		}
+
+		if (this.config.sparkline !== false) {
+			const chartCell = row.createEl('td', { cls: 'stock-chart-cell' });
+			chartCell.createEl('span', {
+				text: 'Failed to load',
+				cls: 'stock-list-error-value'
+			});
+		}
 	}
 
 	private async renderSymbol(container: HTMLElement, symbol: string): Promise<void> {
@@ -296,8 +369,8 @@ export class StockListComponent extends Component {
 		this.config = config;
 	}
 
-	updateData(stockDataArray: StockData[]): void {
-		void this.render(stockDataArray);
+	updateData(stockListData: StockListDataResult): void {
+		void this.render(stockListData);
 	}
 
 	private shouldShowTodayColumn(): boolean {
@@ -327,13 +400,29 @@ export class StockListComponent extends Component {
 		}
 
 		try {
+			this.clearRefreshError();
 			await this.refreshDataCallback();
+		} catch (error: unknown) {
+			this.showRefreshError(getErrorMessage(error, 'Unable to refresh stock data'));
 		} finally {
 			if (refreshBtn) {
 				refreshBtn.disabled = false;
 				refreshBtn.textContent = '↻ Refresh';
 			}
 		}
+	}
+
+	private clearRefreshError(): void {
+		this.container.querySelector('.stock-refresh-error-banner')?.remove();
+	}
+
+	private showRefreshError(message: string): void {
+		this.clearRefreshError();
+
+		const banner = this.container.ownerDocument.createElement('div');
+		banner.className = 'stock-refresh-error-banner';
+		banner.textContent = `Refresh failed: ${message}. Showing last successful data.`;
+		this.container.prepend(banner);
 	}
 
 	private renderHeader(): void {
@@ -379,7 +468,20 @@ export class StockListComponent extends Component {
 		}
 
 		this.sortData();
-		void this.render(this.data);
+		void this.render(this.createCurrentStockListData(), false);
+	}
+
+	private createCurrentStockListData(): StockListDataResult {
+		const errors = this.errors.slice();
+
+		for (const stock of this.data) {
+			const message = this.refreshErrors.get(stock.symbol);
+			if (message) {
+				errors.push({ symbol: stock.symbol, message });
+			}
+		}
+
+		return { stocks: this.data, errors };
 	}
 
 	private sortData(): void {
@@ -419,9 +521,7 @@ export class StockListComponent extends Component {
 		if (this.config.refreshInterval && this.config.refreshInterval > 0) {
 			this.clearAutoRefresh();
 			this.autoRefreshInterval = window.setInterval(() => {
-				if (this.refreshDataCallback) {
-					void this.refreshDataCallback().catch(() => undefined);
-				}
+				void this.refreshData();
 			}, this.config.refreshInterval * 60 * 1000);
 		}
 	}

--- a/src/components/stock-list.ts
+++ b/src/components/stock-list.ts
@@ -4,6 +4,11 @@ import { formatPrice, formatPercentage } from '../utils/formatters';
 import { createTooltip, hideTooltip } from '../utils/tooltip-utils';
 import { createInteractiveSparkline } from '../utils/sparkline-utils';
 import { getErrorMessage } from '../utils/error-utils';
+import { normalizeUniqueTickers } from '../utils/ticker-utils';
+
+type StockListDisplayRow =
+	| { type: 'stock'; stock: StockData }
+	| { type: 'error'; error: StockDataError };
 
 export class StockListComponent extends Component {
 	private container: HTMLElement;
@@ -29,14 +34,9 @@ export class StockListComponent extends Component {
 	}
 
 	async render(stockListData: StockListDataResult, updateTimestamp: boolean = true): Promise<void> {
-		const previousDataBySymbol = new Map(this.data.map(stock => [stock.symbol, stock]));
-		const incomingSymbols = new Set(stockListData.stocks.map(stock => stock.symbol));
-		const preservedData = stockListData.errors
-			.map(error => previousDataBySymbol.get(error.symbol))
-			.filter((stock): stock is StockData => stock !== undefined && !incomingSymbols.has(stock.symbol));
-
-		this.data = stockListData.stocks.concat(preservedData);
-		this.errors = stockListData.errors.filter(error => !previousDataBySymbol.has(error.symbol));
+		const displayData = this.createDisplayStockListData(stockListData);
+		this.data = displayData.stocks;
+		this.errors = displayData.errors;
 		this.refreshErrors = new Map(stockListData.errors.map(error => [error.symbol, error.message]));
 
 		if (updateTimestamp && stockListData.stocks.length > 0) {
@@ -82,51 +82,12 @@ export class StockListComponent extends Component {
 
 		const tbody = table.createEl('tbody');
 
-		for (const stock of this.data) {
-			const row = tbody.createEl('tr', { cls: 'stock-list-row' });
-			const refreshError = this.refreshErrors.get(stock.symbol);
-			if (refreshError) {
-				row.addClass('stock-list-stale-row');
+		for (const row of this.createDisplayRows()) {
+			if (row.type === 'stock') {
+				await this.renderStockRow(tbody, row.stock);
+			} else {
+				this.renderErrorRow(tbody, row.error);
 			}
-
-			const symbolCell = row.createEl('td', { cls: 'stock-symbol-cell' });
-			await this.renderSymbol(symbolCell, stock.symbol);
-			if (refreshError) {
-				this.renderRefreshFailureBadge(symbolCell, refreshError);
-			}
-
-			const priceCell = row.createEl('td', { cls: 'stock-price-cell' });
-			priceCell.setText(formatPrice(stock.price, stock.currency));
-
-			const changeCell = row.createEl('td', { cls: 'stock-change-cell' });
-			changeCell.createEl('span', {
-				text: formatPercentage(stock.changePercent),
-				cls: stock.changePercent >= 0 ? 'stock-change-positive' : 'stock-change-negative'
-			});
-
-			if (this.shouldShowTodayColumn()) {
-				const todayChangeCell = row.createEl('td', { cls: 'stock-today-change-cell' });
-				if (stock.todayChangePercent !== undefined) {
-					todayChangeCell.createEl('span', {
-						text: formatPercentage(stock.todayChangePercent),
-						cls: stock.todayChangePercent >= 0 ? 'stock-change-positive' : 'stock-change-negative'
-					});
-				} else {
-					todayChangeCell.createEl('span', {
-						text: 'N/A',
-						cls: 'stock-today-unavailable'
-					});
-				}
-			}
-
-			if (this.config.sparkline !== false) {
-				const chartCell = row.createEl('td', { cls: 'stock-chart-cell' });
-				this.renderSparkline(chartCell, stock);
-			}
-		}
-
-		for (const error of this.errors) {
-			this.renderErrorRow(tbody, error);
 		}
 
 		if (this.config.showLastUpdate !== false) {
@@ -161,6 +122,107 @@ export class StockListComponent extends Component {
 		}
 
 		this.setupAutoRefresh();
+	}
+
+	private createDisplayStockListData(stockListData: StockListDataResult): StockListDataResult {
+		const previousDataBySymbol = new Map(this.data.map(stock => [stock.symbol, stock]));
+		const incomingDataBySymbol = new Map(stockListData.stocks.map(stock => [stock.symbol, stock]));
+		const errorsBySymbol = new Map(stockListData.errors.map(error => [error.symbol, error]));
+		const stocks: StockData[] = [];
+		const errors: StockDataError[] = [];
+
+		for (const symbol of normalizeUniqueTickers(this.config.tickers)) {
+			const incomingData = incomingDataBySymbol.get(symbol);
+			if (incomingData) {
+				stocks.push(incomingData);
+				continue;
+			}
+
+			const error = errorsBySymbol.get(symbol);
+			if (!error) {
+				continue;
+			}
+
+			const previousData = previousDataBySymbol.get(symbol);
+			if (previousData) {
+				stocks.push(previousData);
+			} else {
+				errors.push(error);
+			}
+		}
+
+		return { stocks, errors };
+	}
+
+	private createDisplayRows(): StockListDisplayRow[] {
+		if (this.config.sortBy) {
+			return [
+				...this.data.map(stock => ({ type: 'stock' as const, stock })),
+				...this.errors.map(error => ({ type: 'error' as const, error }))
+			];
+		}
+
+		const stocksBySymbol = new Map(this.data.map(stock => [stock.symbol, stock]));
+		const errorsBySymbol = new Map(this.errors.map(error => [error.symbol, error]));
+		const rows: StockListDisplayRow[] = [];
+
+		for (const symbol of normalizeUniqueTickers(this.config.tickers)) {
+			const stock = stocksBySymbol.get(symbol);
+			if (stock) {
+				rows.push({ type: 'stock', stock });
+				continue;
+			}
+
+			const error = errorsBySymbol.get(symbol);
+			if (error) {
+				rows.push({ type: 'error', error });
+			}
+		}
+
+		return rows;
+	}
+
+	private async renderStockRow(tbody: HTMLElement, stock: StockData): Promise<void> {
+		const row = tbody.createEl('tr', { cls: 'stock-list-row' });
+		const refreshError = this.refreshErrors.get(stock.symbol);
+		if (refreshError) {
+			row.addClass('stock-list-stale-row');
+		}
+
+		const symbolCell = row.createEl('td', { cls: 'stock-symbol-cell' });
+		await this.renderSymbol(symbolCell, stock.symbol);
+		if (refreshError) {
+			this.renderRefreshFailureBadge(symbolCell, refreshError);
+		}
+
+		const priceCell = row.createEl('td', { cls: 'stock-price-cell' });
+		priceCell.setText(formatPrice(stock.price, stock.currency));
+
+		const changeCell = row.createEl('td', { cls: 'stock-change-cell' });
+		changeCell.createEl('span', {
+			text: formatPercentage(stock.changePercent),
+			cls: stock.changePercent >= 0 ? 'stock-change-positive' : 'stock-change-negative'
+		});
+
+		if (this.shouldShowTodayColumn()) {
+			const todayChangeCell = row.createEl('td', { cls: 'stock-today-change-cell' });
+			if (stock.todayChangePercent !== undefined) {
+				todayChangeCell.createEl('span', {
+					text: formatPercentage(stock.todayChangePercent),
+					cls: stock.todayChangePercent >= 0 ? 'stock-change-positive' : 'stock-change-negative'
+				});
+			} else {
+				todayChangeCell.createEl('span', {
+					text: 'N/A',
+					cls: 'stock-today-unavailable'
+				});
+			}
+		}
+
+		if (this.config.sparkline !== false) {
+			const chartCell = row.createEl('td', { cls: 'stock-chart-cell' });
+			this.renderSparkline(chartCell, stock);
+		}
 	}
 
 	private renderRefreshFailureBadge(container: HTMLElement, message: string): void {

--- a/src/services/stock-data.ts
+++ b/src/services/stock-data.ts
@@ -35,6 +35,10 @@ interface YahooChartResponse {
 	};
 }
 
+interface StockDataRequestOptions {
+	forceRefresh?: boolean;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
 }
@@ -104,6 +108,7 @@ function createOHLCData(open: unknown, high: unknown, low: unknown, close: unkno
 
 export class StockDataService {
 	private cache = new Map<string, CacheEntry>();
+	private pendingRequests = new Map<string, Promise<StockData>>();
 	private cacheDuration: number;
 	private useBusinessDays: boolean;
 	private minDataPoints: number;
@@ -118,30 +123,61 @@ export class StockDataService {
 		this.minDataPoints = minDataPoints;
 	}
 
-	async getStockData(symbol: string, days: number = 30, includeOHLC: boolean = false): Promise<StockData> {
-		const cacheKey = `${symbol}-${days}-${this.useBusinessDays}-${includeOHLC}`;
+	async getStockData(
+		symbol: string,
+		days: number = 30,
+		includeOHLC: boolean = false,
+		options: StockDataRequestOptions = {}
+	): Promise<StockData> {
+		const cleanSymbol = this.normalizeSymbol(symbol);
+		const cacheKey = this.createCacheKey(cleanSymbol, days, includeOHLC);
 		const cached = this.cache.get(cacheKey);
 
-		if (cached && Date.now() - cached.timestamp < this.cacheDuration) {
+		if (!options.forceRefresh && cached && Date.now() - cached.timestamp < this.cacheDuration) {
 			return cached.data;
 		}
 
+		const pendingRequest = this.pendingRequests.get(cacheKey);
+		if (pendingRequest) {
+			return pendingRequest;
+		}
+
+		const request = this.fetchAndCacheStockData(cleanSymbol, days, includeOHLC, cacheKey);
+		this.pendingRequests.set(cacheKey, request);
+		return request;
+	}
+
+	private async fetchAndCacheStockData(
+		cleanSymbol: string,
+		days: number,
+		includeOHLC: boolean,
+		cacheKey: string
+	): Promise<StockData> {
 		try {
-			const data = await this.fetchRealStockData(symbol, days, includeOHLC);
+			const data = await this.fetchRealStockData(cleanSymbol, days, includeOHLC);
 			this.cache.set(cacheKey, {
 				data,
 				timestamp: Date.now()
 			});
 
 			return data;
-			} catch (error: unknown) {
-				// Re-throw the error so the UI can show the Yahoo Finance failure
-				throw new Error(`Yahoo Finance API failed for ${symbol}: ${getErrorMessage(error, 'Network or API error')}`);
-			}
+		} catch (error: unknown) {
+			throw new Error(`Yahoo Finance API failed for ${cleanSymbol}: ${getErrorMessage(error, 'Network or API error')}`);
+		} finally {
+			this.pendingRequests.delete(cacheKey);
 		}
+	}
+
+	private createCacheKey(symbol: string, days: number, includeOHLC: boolean): string {
+		return `${this.normalizeSymbol(symbol)}-${days}-${this.useBusinessDays}-${includeOHLC}`;
+	}
+
+	private normalizeSymbol(symbol: string): string {
+		return symbol.toUpperCase().trim();
+	}
 
 	private async fetchRealStockData(symbol: string, days: number, includeOHLC: boolean = false): Promise<StockData> {
-		const cleanSymbol = symbol.toUpperCase().trim();
+		const cleanSymbol = this.normalizeSymbol(symbol);
 		const dateRange = calculateOptimalDateRange(days, this.useBusinessDays);
 		const url = `https://query1.finance.yahoo.com/v8/finance/chart/${cleanSymbol}?period1=${dateRange.startDate}&period2=${dateRange.endDate}&interval=1d`;
 
@@ -153,21 +189,21 @@ export class StockDataService {
 			}
 		});
 
-			const responseJson: unknown = response.json;
-			if (!isYahooChartResponse(responseJson)) {
-				throw new Error('Invalid response format from Yahoo Finance');
-			}
+		const responseJson: unknown = response.json;
+		if (!isYahooChartResponse(responseJson)) {
+			throw new Error('Invalid response format from Yahoo Finance');
+		}
 
-			const result = responseJson.chart.result[0];
-			const quotes = result?.indicators.quote[0];
-			if (!result || !quotes) {
-				throw new Error(`No data found for symbol ${cleanSymbol}`);
-			}
+		const result = responseJson.chart.result[0];
+		const quotes = result?.indicators.quote[0];
+		if (!result || !quotes) {
+			throw new Error(`No data found for symbol ${cleanSymbol}`);
+		}
 
-			const timestamps = result.timestamp;
-			const closePrices = quotes.close;
-			const openPrices = quotes.open;
-			const highPrices = quotes.high;
+		const timestamps = result.timestamp;
+		const closePrices = quotes.close;
+		const openPrices = quotes.open;
+		const highPrices = quotes.high;
 		const lowPrices = quotes.low;
 
 		const validData: { timestamp: number; price: number; ohlc?: OHLCData }[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,16 @@ export interface StockData {
 	ohlcData?: OHLCData[];
 }
 
+export interface StockDataError {
+	symbol: string;
+	message: string;
+}
+
+export interface StockListDataResult {
+	stocks: StockData[];
+	errors: StockDataError[];
+}
+
 export interface StockListBlockConfig {
 	tickers: string[];
 	days: number;

--- a/src/utils/processor-helpers.ts
+++ b/src/utils/processor-helpers.ts
@@ -1,40 +1,123 @@
 import { StockDataService } from '../services/stock-data';
-import { StockData, StockListBlockConfig, SingleStockBlockConfig } from '../types';
+import { StockData, StockDataError, StockListBlockConfig, StockListDataResult, SingleStockBlockConfig } from '../types';
+import { getErrorMessage } from './error-utils';
+
+const MAX_STOCK_LIST_CONCURRENCY = 6;
+
+type StockListRequestResult =
+	| { status: 'success'; stock: StockData }
+	| { status: 'error'; error: StockDataError };
 
 interface StockDataFetcher {
-	fetchListData(config: StockListBlockConfig): Promise<StockData[]>;
+	fetchListData(config: StockListBlockConfig): Promise<StockListDataResult>;
 	fetchChartData(config: SingleStockBlockConfig): Promise<StockData>;
-	createListRefreshFetcher(config: StockListBlockConfig): () => Promise<StockData[]>;
+	createListRefreshFetcher(config: StockListBlockConfig): () => Promise<StockListDataResult>;
 	createChartRefreshFetcher(config: SingleStockBlockConfig): () => Promise<StockData>;
+}
+
+async function mapWithConcurrency<TInput, TOutput>(
+	items: TInput[],
+	limit: number,
+	mapper: (item: TInput, index: number) => Promise<TOutput>
+): Promise<TOutput[]> {
+	const results = new Array<TOutput>(items.length);
+	let nextIndex = 0;
+	const workerCount = Math.min(limit, items.length);
+	const workers: Promise<void>[] = [];
+
+	for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+		workers.push((async () => {
+			while (nextIndex < items.length) {
+				const currentIndex = nextIndex;
+				nextIndex++;
+				results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+			}
+		})());
+	}
+
+	await Promise.all(workers);
+	return results;
+}
+
+function normalizeTicker(ticker: string): string {
+	return ticker.trim().toUpperCase();
+}
+
+function normalizeUniqueTickers(tickers: string[]): string[] {
+	const normalizedTickers: string[] = [];
+	const seenTickers = new Set<string>();
+
+	for (const ticker of tickers) {
+		const normalizedTicker = normalizeTicker(ticker);
+		if (normalizedTicker.length === 0 || seenTickers.has(normalizedTicker)) {
+			continue;
+		}
+
+		seenTickers.add(normalizedTicker);
+		normalizedTickers.push(normalizedTicker);
+	}
+
+	return normalizedTickers;
+}
+
+async function fetchStockListData(
+	stockDataService: StockDataService,
+	config: StockListBlockConfig,
+	forceRefresh: boolean
+): Promise<StockListDataResult> {
+	const tickers = normalizeUniqueTickers(config.tickers);
+	const requestResults = await mapWithConcurrency(
+		tickers,
+		MAX_STOCK_LIST_CONCURRENCY,
+		async (ticker: string): Promise<StockListRequestResult> => {
+			try {
+				const stock = await stockDataService.getStockData(ticker, config.days, false, { forceRefresh });
+				return { status: 'success', stock };
+			} catch (error: unknown) {
+				return {
+					status: 'error',
+					error: {
+						symbol: ticker,
+						message: getErrorMessage(error, 'Unable to load stock data')
+					}
+				};
+			}
+		}
+	);
+
+	const stocks: StockData[] = [];
+	const errors: StockDataError[] = [];
+
+	for (const result of requestResults) {
+		if (result.status === 'success') {
+			stocks.push(result.stock);
+		} else {
+			errors.push(result.error);
+		}
+	}
+
+	return { stocks, errors };
 }
 
 export function createStockDataFetcher(stockDataService: StockDataService): StockDataFetcher {
 	return {
-		async fetchListData(config: StockListBlockConfig): Promise<StockData[]> {
-			const stockDataPromises = config.tickers.map((ticker: string) => 
-				stockDataService.getStockData(ticker.trim(), config.days)
-			);
-			return Promise.all(stockDataPromises);
+		async fetchListData(config: StockListBlockConfig): Promise<StockListDataResult> {
+			return fetchStockListData(stockDataService, config, false);
 		},
 
 		async fetchChartData(config: SingleStockBlockConfig): Promise<StockData> {
-			return stockDataService.getStockData(config.symbol, config.days, config.useCandles);
+			return stockDataService.getStockData(config.symbol, config.days, config.useCandles === true);
 		},
 
-		createListRefreshFetcher(config: StockListBlockConfig): () => Promise<StockData[]> {
-			return async (): Promise<StockData[]> => {
-				stockDataService.clearCache();
-				const freshDataPromises = config.tickers.map((ticker: string) => 
-					stockDataService.getStockData(ticker.trim(), config.days)
-				);
-				return Promise.all(freshDataPromises);
+		createListRefreshFetcher(config: StockListBlockConfig): () => Promise<StockListDataResult> {
+			return async (): Promise<StockListDataResult> => {
+				return await fetchStockListData(stockDataService, config, true);
 			};
 		},
 
 		createChartRefreshFetcher(config: SingleStockBlockConfig): () => Promise<StockData> {
 			return async (): Promise<StockData> => {
-				stockDataService.clearCache();
-				return stockDataService.getStockData(config.symbol, config.days, config.useCandles);
+				return await stockDataService.getStockData(config.symbol, config.days, config.useCandles === true, { forceRefresh: true });
 			};
 		}
 	};
@@ -42,7 +125,7 @@ export function createStockDataFetcher(stockDataService: StockDataService): Stoc
 
 export const validators = {
 	stockList: (config: StockListBlockConfig): string | null => {
-		return config.tickers.length === 0 ? 'No tickers specified. Add tickers like: tickers: AAPL, MSFT, NVDA' : null;
+		return normalizeUniqueTickers(config.tickers).length === 0 ? 'No tickers specified. Add tickers like: tickers: AAPL, MSFT, NVDA' : null;
 	},
 
 	stockChart: (config: SingleStockBlockConfig): string | null => {

--- a/src/utils/processor-helpers.ts
+++ b/src/utils/processor-helpers.ts
@@ -1,6 +1,7 @@
 import { StockDataService } from '../services/stock-data';
 import { StockData, StockDataError, StockListBlockConfig, StockListDataResult, SingleStockBlockConfig } from '../types';
 import { getErrorMessage } from './error-utils';
+import { normalizeUniqueTickers } from './ticker-utils';
 
 const MAX_STOCK_LIST_CONCURRENCY = 6;
 
@@ -37,27 +38,6 @@ async function mapWithConcurrency<TInput, TOutput>(
 
 	await Promise.all(workers);
 	return results;
-}
-
-function normalizeTicker(ticker: string): string {
-	return ticker.trim().toUpperCase();
-}
-
-function normalizeUniqueTickers(tickers: string[]): string[] {
-	const normalizedTickers: string[] = [];
-	const seenTickers = new Set<string>();
-
-	for (const ticker of tickers) {
-		const normalizedTicker = normalizeTicker(ticker);
-		if (normalizedTicker.length === 0 || seenTickers.has(normalizedTicker)) {
-			continue;
-		}
-
-		seenTickers.add(normalizedTicker);
-		normalizedTickers.push(normalizedTicker);
-	}
-
-	return normalizedTickers;
 }
 
 async function fetchStockListData(

--- a/src/utils/ticker-utils.ts
+++ b/src/utils/ticker-utils.ts
@@ -1,0 +1,20 @@
+export function normalizeTicker(ticker: string): string {
+	return ticker.trim().toUpperCase();
+}
+
+export function normalizeUniqueTickers(tickers: string[]): string[] {
+	const normalizedTickers: string[] = [];
+	const seenTickers = new Set<string>();
+
+	for (const ticker of tickers) {
+		const normalizedTicker = normalizeTicker(ticker);
+		if (normalizedTicker.length === 0 || seenTickers.has(normalizedTicker)) {
+			continue;
+		}
+
+		seenTickers.add(normalizedTicker);
+		normalizedTickers.push(normalizedTicker);
+	}
+
+	return normalizedTickers;
+}

--- a/styles.css
+++ b/styles.css
@@ -124,6 +124,53 @@
 	font-size: 0.9em;
 }
 
+.stock-list-stale-row {
+	background-color: var(--background-primary-alt);
+}
+
+.stock-list-error-row {
+	background-color: var(--background-modifier-error);
+}
+
+.stock-refresh-failed-badge {
+	display: inline-block;
+	margin-left: 0.5rem;
+	padding: 0.05rem 0.35rem;
+	border: 1px solid var(--background-modifier-error-border);
+	border-radius: 4px;
+	color: var(--color-red);
+	background-color: var(--background-modifier-error);
+	font-size: 0.7rem;
+	font-weight: 500;
+	vertical-align: middle;
+}
+
+.stock-list-error-value,
+.stock-list-row-error-message {
+	color: var(--color-red);
+	font-size: 0.85rem;
+}
+
+.stock-list-row-error-message {
+	display: inline-block;
+	max-width: 28rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	vertical-align: bottom;
+}
+
+.stock-refresh-error-banner {
+	margin-bottom: 0.75rem;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--background-modifier-error-border);
+	border-radius: 6px;
+	color: var(--color-red);
+	background-color: var(--background-modifier-error);
+	font-size: 0.85rem;
+	line-height: 1.4;
+}
+
 .stock-chart-cell {
 	text-align: center;
 }


### PR DESCRIPTION
## Summary
- Deduplicates in-flight Yahoo requests and normalizes cache keys so duplicate simultaneous loads share one fetch instead of racing the network.
- Replaces all-or-nothing stock list loading with bounded-concurrency partial results, so one bad symbol no longer breaks the whole block.
- Switches refresh to scoped, block-level behavior with stale-data preservation and visible refresh errors for both stock lists and charts.
- Documents the new behavior and adds UI styling for stale rows, partial failures, and refresh banners.

## Testing
- `npm run lint` passed.
- `npm run build` passed.
- `git diff --check` passed.
- Manual validation covered request deduping, partial list failures, stale-data refresh behavior, and refresh error UI handling.